### PR TITLE
Fix Typo causing save point track not working

### DIFF
--- a/entities/CompetitionPointTrackJson.js
+++ b/entities/CompetitionPointTrackJson.js
@@ -25,7 +25,7 @@ module.exports = (sequelize) => {
       },
     },
     {
-      modelName: 'competitionPointTrackJson',
+      modelName: 'CompetitionPointTrackJson',
       sequelize,
       timestamps: false,
     },


### PR DESCRIPTION
Very minor changes, the c should be Uppercase

2021-10-01T03:53:20.548Z [analysis-engine] [31merror[39m: [31mFailed to save competition results. Error: relation "competitionPointTrackJsons" does not exist[39m