### PR TITLE
Re-add lon, lat on model definition

### DIFF
--- a/entities/CalendarEvent.js
+++ b/entities/CalendarEvent.js
@@ -50,6 +50,12 @@ module.exports = (sequelize) => {
       locationName: {
         type: DataTypes.STRING,
       },
+      lon: {
+        type: DataTypes.FLOAT,
+      },
+      lat: {
+        type: DataTypes.FLOAT,
+      },
       location: {
         type: DataTypes.GEOMETRY('POINT', 4326),
       },


### PR DESCRIPTION
The latest Fix on Open Graph used the latest data model where lon lat is not defined, but the code for public event is not merged yet, so it's not returning lon lat right now eventhough the column still exists, causing FE dev to crashes. This is temporary fix, and will be removed together with the lon, lat migration removal.