### PR TITLE
[FIX] Update member count on my groups fetch

### DIFF
--- a/dataAccess/v1/groupMember.js
+++ b/dataAccess/v1/groupMember.js
@@ -210,7 +210,7 @@ exports.getGroupsByUserId = async (paging, { userId, status }) => {
         },
       ],
       replacements: {
-        status,
+        status: groupMemberStatus.accepted,
       },
     },
     paging,


### PR DESCRIPTION
Status on member count should always be accepted, not based on input status