### PR TITLE
Add calendarEventId definition

### DIFF
--- a/entities/Participant.js
+++ b/entities/Participant.js
@@ -43,6 +43,9 @@ module.exports = (sequelize) => {
       calendarEventId: {
         type: DataTypes.UUID,
       },
+      userProfileId: {
+        type: DataTypes.UUID,
+      },
     },
     {
       modelName: 'Participant',


### PR DESCRIPTION
Need to be defined since analysis engine and puppeteer service are not using the associate functions on the schema.