### PR TITLE
Add My Event to return Event they join as well

### DIFF
--- a/dataAccess/v1/calendarEvent.js
+++ b/dataAccess/v1/calendarEvent.js
@@ -424,6 +424,9 @@ exports.getUserEvents = async (paging, userId) => {
               [db.Op.ne]: null,
             },
           ),
+          db.sequelize.where(db.sequelize.literal(`"participants"."id"`), {
+            [db.Op.ne]: null,
+          }),
         ],
       },
     ],
@@ -478,6 +481,16 @@ exports.getUserEvents = async (paging, userId) => {
           ],
           required: false,
         },
+        // Participating in events
+        {
+          model: db.Participant,
+          as: 'participants',
+          attributes: ['id'],
+          where: {
+            userProfileId: userId,
+          },
+          required: false,
+        },
       ],
       replacements: {
         userId,
@@ -516,10 +529,10 @@ exports.getUserEvents = async (paging, userId) => {
 exports.getByScrapedOriginalIdAndSource = async (originalIds, source) => {
   const where = {
     source,
-  }
+  };
   if (originalIds instanceof Array) {
     where.scrapedOriginalId = {
-      [db.Op.in]: originalIds
+      [db.Op.in]: originalIds,
     };
   } else {
     where.scrapedOriginalId = originalIds;
@@ -528,4 +541,4 @@ exports.getByScrapedOriginalIdAndSource = async (originalIds, source) => {
     attributes: ['id', 'scrapedOriginalId'],
     where,
   });
-}
+};


### PR DESCRIPTION
- On mobile, when I join an event by selecting a flag on the mobile app and beginning to track, that event doesn’t show up on my events list on the web app.
- When I click a tracking link and can track successfully, I can see the event in my events on mobile, but I can’t see it in my events on web even though I can see it in my tracks. 

For this issue in bug docs