### PR TITLE
Add Bulk Get Editors (Event)

### DIFF
--- a/dataAccess/v1/calendarEvent.js
+++ b/dataAccess/v1/calendarEvent.js
@@ -695,14 +695,14 @@ exports.getBulkEventEditors = async (idList) => {
   });
 
   groupEditors.forEach((row) => {
-    const { calendarEventId, user } = row;
+    const { calendarEventId, group } = row;
     if (!calendarEventEditors[calendarEventId]) {
       calendarEventEditors[calendarEventId] = {
         editors: [],
         groupEditors: [],
       };
     }
-    calendarEventEditors[calendarEventId].groupEditors.push(user);
+    calendarEventEditors[calendarEventId].groupEditors.push(group);
   });
   return calendarEventEditors;
 };


### PR DESCRIPTION
Since the participants, editors, and groupEditors from my events are used only to filter based on the user ID, these 3 fields will never show correct result on the my-event page.
So we need to replace the values with correct data.