### PR TITLE
Bugfix: Use sail number of vessel participant whenever possible

### DIFF
--- a/dataAccess/v1/vessel.js
+++ b/dataAccess/v1/vessel.js
@@ -213,7 +213,7 @@ exports.getAllRegisteredInEvent = async (eventId, paging = {}) => {
 
   const vpWithCrews = (
     await db.VesselParticipant.findAll({
-      attributes: ['id', 'vesselId'],
+      attributes: ['id', 'vesselId', 'sailNumber'],
       where: {
         vesselId: {
           [db.Op.in]: result.rows.map((t) => t.id),
@@ -262,8 +262,10 @@ exports.getAllRegisteredInEvent = async (eventId, paging = {}) => {
 
   result.rows = result.rows.map((t) => {
     const vessel = t.toJSON();
+    const vp = vpWithCrews.filter((vp) => vp.vesselId === vessel.id);
     return {
       ...vessel,
+      sailNumber: vp[0]?.sailNumber ?? vessel.sailNumber,
       vesselParticipants: vpWithCrews.filter((vp) => vp.vesselId === vessel.id),
     };
   });


### PR DESCRIPTION
Updating return from this endpoint to use sailnumber from vp first if available
Will be used in this list:
![image](https://user-images.githubusercontent.com/46771684/170181486-3592b50e-656a-47f8-af02-55a4437635ef.png)
