### PR TITLE
Bugfix : SNS-1064 Fallback reverse geo code when Google API returns null

### DIFF
--- a/dataAccess/v1/competitionUnit.js
+++ b/dataAccess/v1/competitionUnit.js
@@ -334,6 +334,7 @@ exports.updateCountryCity = async (
             type: 'Point',
             coordinates: data.centerPoint,
           },
+      approximateStart_zone: data?.timezone,
     },
     {
       where: {


### PR DESCRIPTION
update approximateStart_zone when updating race city and country 