### PR TITLE
Bugfix : SNS-992 Change queue name

### DIFF
--- a/enums.js
+++ b/enums.js
@@ -177,7 +177,7 @@ const miscOptionsValue = {
 
 const bullQueues = {
   raceStart: 'race_start',
-  expeditionSubsExpiration: 'expedition_subs_expiration',
+  expeditionSubsExpiration: 'expedition_stream_expiration',
   openGraph: 'open_graph',
   closestCity: 'closest_city',
   yachtScoringTestCredentials: 'yachtscoring_test_credentials',


### PR DESCRIPTION
Change queue name for expedition subscription so we can delete all keys related to previous queue